### PR TITLE
Make the SizePreferenceKey.defaultValue a constant

### DIFF
--- a/Sources/ClusterMapSwiftUI/SizeReader.swift
+++ b/Sources/ClusterMapSwiftUI/SizeReader.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct SizePreferenceKey: PreferenceKey {
-    static var defaultValue: CGSize = .zero
+    static let defaultValue: CGSize = .zero
     static func reduce(value: inout CGSize, nextValue: () -> CGSize) { }
 }
 


### PR DESCRIPTION
Changing this to a constant will make it compatible with Swift 6. 

Global mutable variables are not concurrency safe and Swift 6 treats it as an error.

This is the only line in the ClusterMap repo that is not compatible with Swift 6