### PR TITLE
Changed batch operations to accept any sequence

### DIFF
--- a/Sources/ClusterMap/Public/Core/ClusterManager.swift
+++ b/Sources/ClusterMap/Public/Core/ClusterManager.swift
@@ -61,7 +61,7 @@ public actor ClusterManager<Annotation: CoordinateIdentifiable>
     /// Adds multiple annotations to the cluster manager.
     ///
     /// - Parameter annotations: An array of annotations to be added.
-    public func add(_ annotations: [Annotation]) {
+    public func add<Annotations: Sequence>(_ annotations: Annotations) where Annotations.Element == Annotation {
         annotations.forEach { tree.add($0) }
     }
 
@@ -75,7 +75,7 @@ public actor ClusterManager<Annotation: CoordinateIdentifiable>
     /// Removes multiple annotations from the cluster manager.
     ///
     /// - Parameter annotations: An array of annotations to be removed.
-    public func remove(_ annotations: [Annotation]) {
+    public func remove<Annotations: Sequence>(_ annotations: Annotations) where Annotations.Element == Annotation {
         annotations.forEach { tree.remove($0) }
     }
 


### PR DESCRIPTION
Since the batch operations of `ClusterManager` only use the `.forEach` method, I changed the methods to accept any generic sequence.